### PR TITLE
Correct timestamp display

### DIFF
--- a/lib/message-list/index.js
+++ b/lib/message-list/index.js
@@ -28,7 +28,7 @@ const MessageList = ({
       active={rowData.active}
       title={rowData.title}
       message={rowData.message}
-      timestamp={timestamp}
+      timestamp={rowData.timestamp}
       onPress={() => onPress(rowData.id)}
       style={messageStyle}
       containerStyle={messageContainerStyle}


### PR DESCRIPTION
In the MessageList component, previously it would only show the current time because it was accessing a non-existent standalone timestamp variable, but has now been changed to access the correct rowData element.